### PR TITLE
Fixed Genre Page readability

### DIFF
--- a/src/modules/Genre/Genre.css
+++ b/src/modules/Genre/Genre.css
@@ -50,6 +50,8 @@
 
 .track-index {
   vertical-align: top;
+  padding: 10px;
+  margin-top: -4%;
 }
 
 .genre-details {

--- a/src/modules/Genre/Genre.css
+++ b/src/modules/Genre/Genre.css
@@ -4,14 +4,14 @@
   grid-auto-flow: column;
 }
 
-.image-col {
-  align-items: left;
-  width: 500px;
+.image-col{
+  max-width: 100%;
+  height: auto;
 }
 
 .desc-col {
   align-items: right;
-  width: 700px;
+  width: auto;
 }
 
 .container {
@@ -20,9 +20,10 @@
   max-width: 400px;
 }
 
-.col {
-  align-items: center;
+.column {
   width: 250px;
+  display: flex;
+  align-items: start;
 }
 
 .genre-description {
@@ -35,11 +36,20 @@
 .genre-name {
   text-align: center;
   align-items: center;
+  font-size: 0.5em;
 }
 
 .artist-name {
-  margin-left: 12%;
   align-items: center;
+  font-size: 0.7em;
+}
+
+.track-name-and-artist {
+  align-items: flex-start;
+}
+
+.track-index {
+  vertical-align: top;
 }
 
 .genre-details {

--- a/src/modules/Genre/Genre.js
+++ b/src/modules/Genre/Genre.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { useState } from 'react';
 import './Genre.css';
 import PlayButton from '../PlayButton/PlayButton';
+import genreImages from '../../assets/genre_images/genreImages';
 
 function stripHtml(html) {
   let tmp = document.createElement("DIV");
@@ -17,7 +18,7 @@ function Genre(props) {
 
   // To get Genre Description:
   // Pass in genre ID -> genre API -> (genre) name, description
-  
+
   /**
   * Some api endpoints work using shortcut name, but some don't.
   * All work with the genreID, so we will use that for all calls
@@ -52,7 +53,7 @@ function Genre(props) {
         // console.log(genreDetails);
       })
       .then(function (response) {
-        genreDetails.genreImageSrc = "https://api.napster.com/imageserver/images/" + genreID + "/240x160.jpg";
+        genreDetails.genreImageSrc = genreImages[genreDetails.genreName];
         setGenreDetailsData([genreDetails]);
         return fetch("https://api.napster.com/v2.2/genres/" + genreID + "/tracks/top?apikey=" + API_KEY);
       })
@@ -115,9 +116,9 @@ function Genre(props) {
     console.log('updated song list');
     songListDOMElement.push(
       <div className="song row">
-        <div className="song-image col">
+        <div className="song-image column">
           <div className="container">
-            <img src={track.songImageSrc} alt={"Image Representing " + track.songName} className="image col" />
+            <img src={track.songImageSrc} alt={"Image Representing " + track.songName} className="image column" />
             <div className="overlay">
               <div className="icon">
                 <PlayButton previewProp={track.trackPreviewSrc} />
@@ -125,13 +126,17 @@ function Genre(props) {
             </div>
           </div>
         </div>
-        <div className="song-name col">
-          <span>{track.trackIndex + '. '}</span>
-          <a href={"/song/" + track.trackShortcut} className="link-to-track">
-            {track.songName}
-          </a>
-          <div className="artist-name list-col">
-            {track.artistName}
+        <div className="song-name column">
+          <div className="track-index">
+            <span class="track-index">{track.trackIndex + '. '}</span>
+          </div>
+          <div className=".track-name-and-artist">
+            <a href={"/song/" + track.trackShortcut} className="link-to-track">
+              {track.songName}
+            </a>
+            <div className="artist-name">
+              {track.artistName}
+            </div>
           </div>
         </div>
       </div>
@@ -142,9 +147,9 @@ function Genre(props) {
     // Change to ids
     <div className="Song">
       <h2 className="genre-header">{genreNameDOMElement}</h2>
-      <div className="holder flex-row-item">        
-          <div className="song flex-row-item">
-            {genreDetailsDOMElement}
+      <div className="holder flex-row-item">
+        <div className="song flex-row-item">
+          {genreDetailsDOMElement}
         </div>
       </div>
       <div className="Song-album">

--- a/src/modules/Genre/Genre.js
+++ b/src/modules/Genre/Genre.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { useState } from 'react';
 import './Genre.css';
 import PlayButton from '../PlayButton/PlayButton';
@@ -127,9 +127,7 @@ function Genre(props) {
           </div>
         </div>
         <div className="song-name column">
-          <div className="track-index">
-            <span class="track-index">{track.trackIndex + '. '}</span>
-          </div>
+          <div class="track-index" >{track.trackIndex + '.'}</div>
           <div className=".track-name-and-artist">
             <a href={"/song/" + track.trackShortcut} className="link-to-track">
               {track.songName}


### PR DESCRIPTION
Aligned song index number with the song name.
Genre Description now auto resizes depending on the window size.
Made the Genre name smaller.
Genre images are now grabbed from the assets folder

![image](https://user-images.githubusercontent.com/30790329/128621946-5dbc8ceb-2ed4-4dd6-a3a1-5e0dc1ec8af0.png)
![image](https://user-images.githubusercontent.com/30790329/128621949-79946c1a-57b3-4c14-a7c5-a78abc6566d5.png)
