### PR TITLE
Normalized spacing between page headers and navbar

### DIFF
--- a/src/modules/Genre/Genre.module.css
+++ b/src/modules/Genre/Genre.module.css
@@ -27,7 +27,7 @@
 }
 
 .genre-header { /* Change later */
-  margin: 0;
+  /* margin: 0; */
   font-weight: normal;
   font-size: 3em;
 }
@@ -39,7 +39,7 @@
   justify-content: space-evenly;
   margin-left: 15%;
   margin-right: 15%;
-  margin-top: 2%;
+  /* margin-top: 2%; */
   margin-bottom: 2%;
 }
 
@@ -52,7 +52,7 @@
   margin-right: 5%;
 }
 
-.image-col{
+.image-col {
   width: 18.75em; /* 300 px */
 }
 

--- a/src/modules/Home/Home.js
+++ b/src/modules/Home/Home.js
@@ -55,12 +55,10 @@ function Home(props) {
 
   return (
     <div id={`home`}>
-      <div className={`${styles["flex-column-container"]}`}>
-        <div id={`${styles["discover-genres"]}`} className={`${styles["flex-column-container"]}`}>
-          <h2>Discover Music</h2>
-          <div id={`${styles["genre-list"]}`} className={`${styles["flex-row-container"]}`}>
-            {genreDOMElements}
-          </div>
+      <div id={`${styles["discover-genres"]}`} className={`${styles["flex-column-container"]}`}>
+        <h2>Discover Music</h2>
+        <div id={`${styles["genre-list"]}`} className={`${styles["flex-row-container"]}`}>
+          {genreDOMElements}
         </div>
       </div>
     </div>

--- a/src/modules/Home/Home.module.css
+++ b/src/modules/Home/Home.module.css
@@ -10,19 +10,27 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  /* border: 2px red solid; */
+}
+
+#discover-genres {
+  padding-bottom: 5em;
 }
 
 #discover-genres h2 {
-  margin: 0;
+  /* margin: 0; */
   font-weight: normal;
   font-size: 3em;
+  
 }
 
 #genre-list {
   background-color: rgb(182, 182, 182);
   width: 50%;
   justify-content: space-evenly;
-  margin: 2.5%;
+  /* border: 2px red solid; */
+  /* margin: 2.5%; */
+  padding: 1em;
 }
 
 .genre {

--- a/src/modules/SearchPage/SearchPage.js
+++ b/src/modules/SearchPage/SearchPage.js
@@ -74,26 +74,28 @@ function SearchPage(props) {
   */
 
   return (
-    <div id={styles["search-page"]} className={styles["flex-column-container"]}>
+    <div id={styles["search-page"]}>
+      <div className={styles["flex-column-container"]}>
         {trackData.isDataRetrieved 
-          ? 
-            <div id={styles["top-matching-songs"]} className={styles["flex-column-container"]}>
-              <h2>Top Matching Songs</h2>
-              {trackData.actualTrackData.length
-                ? 
-                  <div id={styles["track-list"]} className={styles["flex-column-container"]}>
-                    {trackDOMElements}
-                  </div>
-                :
-                  <h3>No songs found!</h3> 
-              }
-            </div>
-          :
-            <div id={styles["top-matching-songs"]} className={styles["flex-column-container"]}>
-              <h2>Top Matching Songs</h2>
-              <span>Loading...</span>
-            </div>
+            ? 
+              <div id={styles["top-matching-songs"]} className={styles["flex-column-container"]}>
+                <h2>Top Matching Songs</h2>
+                {trackData.actualTrackData.length
+                  ? 
+                    <div id={styles["track-list"]} className={styles["flex-column-container"]}>
+                      {trackDOMElements}
+                    </div>
+                  :
+                    <h3>No songs found!</h3> 
+                }
+              </div>
+            :
+              <div id={styles["top-matching-songs"]} className={styles["flex-column-container"]}>
+                <h2>Top Matching Songs</h2>
+                <span>Loading...</span>
+              </div>
         }
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The spacing between page headers and the navbar was inconsistent and uncomfortable, specifically the Home page and Genre Page.

The new spacing: 

![image](https://user-images.githubusercontent.com/49804462/133961792-0bdb409a-0a1b-4c67-abac-16c51114a7d1.png)

![image](https://user-images.githubusercontent.com/49804462/133961809-45baf348-791d-4136-8090-4720260f2a8a.png)

I would recommend you compare with your local version to see the difference.

@lchua2314 since you recently refactored the Genre page and I tweaked it a bit just now, please make sure the changes I made don't mess up anything.