### PR TITLE
fixed a bug where Genre pages' top songs were not showing up

### DIFF
--- a/src/modules/Genre/Genre.js
+++ b/src/modules/Genre/Genre.js
@@ -60,7 +60,7 @@ function Genre(props) {
       .then(function (response) {
         genreDetails.genreImageSrc = genreImages[genreDetails.genreName];
         setGenreDetailsData([genreDetails]);
-        return fetch("https://api.napster.com/v2.2/genres/" + genreID + "/tracks/top?apikey=" + props.NAPSTER_API_KEY);
+        return fetch("https://api.napster.com/v2/genres/" + genreID + "/tracks/top?apikey=" + props.NAPSTER_API_KEY);
       })
       .then(function (response) {
         // Albums API successful response


### PR DESCRIPTION
Apparently, Napster API version 2.2 is bugged for this endpoint. Reverting from 2.2 to 2.0 will fix this issue. However, don't revert every API call using 2.2 since it broke other things.